### PR TITLE
fix: feature result shall not ignore failing scenario

### DIFF
--- a/cucumber_cpp/library/engine/TestRunner.cpp
+++ b/cucumber_cpp/library/engine/TestRunner.cpp
@@ -248,6 +248,7 @@ namespace cucumber_cpp::engine
 
         void RunScenarios(ContextManager& contextManager, const std::vector<std::unique_ptr<ScenarioInfo>>& scenarios, report::ReportHandlerV2& reportHandler, const RunPolicy& runPolicy)
         {
+            bool allScenariosPassed = true;
             for (const auto& scenario : scenarios)
             {
                 ContextManager::ScopedContextLock contextScope{ contextManager.StartScope(*scenario) };
@@ -260,7 +261,9 @@ namespace cucumber_cpp::engine
                 runPolicy.ExecuteHook(contextManager, HookType::after, scenario->Tags());
 
                 reportHandler.ScenarioEnd(contextManager.CurrentContext().ExecutionStatus(), *scenario, contextManager.CurrentContext().Duration());
+                allScenariosPassed &= contextManager.CurrentContext().ExecutionStatus() == Result::passed;
             }
+            contextManager.CurrentContext().ExecutionStatus(allScenariosPassed ? Result::passed : Result::failed);
         }
 
         void RunRules(ContextManager& contextManager, const std::vector<std::unique_ptr<RuleInfo>>& rules, report::ReportHandlerV2& reportHandler, const RunPolicy& runPolicy)


### PR DESCRIPTION
Currently, the result of a feature reflects the result of its last scenario. That is not always correct.

Example:
- First scenario: `failed`
- Second scenario: `passed`
- Feature: `passed`

In this example, I would have expected the feature to be `failed` as well. 

This PR changes that behavior. A feature is only `passed` when all its scenarios are `passed`, otherwise it `failed`.