### PR TITLE
Escaping in cucumber expressions.

### DIFF
--- a/cucumber_cpp/acceptance_test/features/test_escape_expression.feature
+++ b/cucumber_cpp/acceptance_test/features/test_escape_expression.feature
@@ -8,5 +8,5 @@ Feature: Cucumber expressions escape sequence
 
     Scenario: To test braced expression
         Given a given step
-        Then An expression with {brace} should remain as is
-        Then An expression with \{escaped parenthesis\} should keep the slash
+        Then An expression with {braces} should remain as is
+        Then An expression with \{escaped braces\} should keep the slash

--- a/cucumber_cpp/acceptance_test/features/test_escape_expression.feature
+++ b/cucumber_cpp/acceptance_test/features/test_escape_expression.feature
@@ -1,0 +1,12 @@
+@smoke
+Feature: Cucumber expressions escape sequence
+    Scenario: To test parenthesized expression
+        Given a given step
+        Then An expression with (parenthesis) should remain as is
+        Then An expression that looks like a function func(1, 2) should keep its parameters
+        Then An expression with \(escaped parenthesis\) should keep the slash
+
+    Scenario: To test braced expression
+        Given a given step
+        Then An expression with {brace} should remain as is
+        Then An expression with \{escaped parenthesis\} should keep the slash

--- a/cucumber_cpp/acceptance_test/steps/Steps.cpp
+++ b/cucumber_cpp/acceptance_test/steps/Steps.cpp
@@ -67,13 +67,13 @@ THEN(R"(An expression with \\(escaped parenthesis\\) should keep the slash)")
     // empty
 }
 
-THEN(R"(An expression with \{parenthesis} should remain as is)")
+THEN(R"(An expression with \{braces} should remain as is)")
 {
     // empty
 }
 
 
-THEN(R"(An expression with \\{escaped parenthesis\\} should keep the slash)")
+THEN(R"(An expression with \\{escaped braces\\} should keep the slash)")
 {
     // empty
 }

--- a/cucumber_cpp/acceptance_test/steps/Steps.cpp
+++ b/cucumber_cpp/acceptance_test/steps/Steps.cpp
@@ -49,3 +49,31 @@ WHEN("I print {string} with value {int}", (const std::string& str, std::int32_t 
 {
     std::cout << "print: " << str << " with value " << value;
 }
+
+
+THEN(R"(An expression with \(parenthesis) should remain as is)")
+{
+    // empty
+}
+
+THEN(R"(An expression that looks like a function func\({int}, {int}) should keep its parameters)", (int a, int b))
+{
+    EXPECT_THAT(a, testing::Eq(1));
+    EXPECT_THAT(b, testing::Eq(2));
+}
+
+THEN(R"(An expression with \\(escaped parenthesis\\) should keep the slash)")
+{
+    // empty
+}
+
+THEN(R"(An expression with \{parenthesis} should remain as is)")
+{
+    // empty
+}
+
+
+THEN(R"(An expression with \\{escaped parenthesis\\} should keep the slash)")
+{
+    // empty
+}


### PR DESCRIPTION
Greetings,

This PR adds a test case for https://github.com/philips-software/amp-cucumber-cpp-runner/issues/178 

How would you like me to continue with the actual fix? Two options that I can think of are:

1. Additional manual parsing in C++ prior to regex operation to avoid unnecessary match
2. Use a different regex library that supports lookbehind `(?<!\\)(.\))`. Though I imagine adding a whole new library just for this case may be excessive.