### PR TITLE
feat: add option to print steps that have not been used

### DIFF
--- a/cucumber_cpp/library/Application.hpp
+++ b/cucumber_cpp/library/Application.hpp
@@ -40,6 +40,7 @@ namespace cucumber_cpp::library
             std::string reportfile{ "TestReport" };
 
             bool dryrun{ false };
+            bool printStepsNotUsed{ false };
         };
 
         explicit Application(std::shared_ptr<ContextStorageFactory> contextStorageFactory = std::make_shared<ContextStorageFactoryImpl>());


### PR DESCRIPTION
Added a CLI flag to show the step definitions that were not used during the test run. This is helpful in removing obsolete steps and thus dead code.