### PR TITLE
feat: add gherkin doc string support

### DIFF
--- a/cucumber_cpp/acceptance_test/features/test_doc_strings.feature
+++ b/cucumber_cpp/acceptance_test/features/test_doc_strings.feature
@@ -1,0 +1,8 @@
+Feature: Doc Strings
+
+  Scenario: Multiline doc strings
+    Given Next block of text enclosed in """ characters
+      """
+      Multiline
+      Docstring
+      """

--- a/cucumber_cpp/acceptance_test/steps/Steps.cpp
+++ b/cucumber_cpp/acceptance_test/steps/Steps.cpp
@@ -54,3 +54,9 @@ THEN("this should be skipped")
 {
     FAIL();
 }
+
+GIVEN("Next block of text enclosed in \"\"\" characters")
+{
+
+    ASSERT_THAT(docString, testing::Eq("Multiline\nDocstring"));
+}

--- a/cucumber_cpp/library/StepRegistry.cpp
+++ b/cucumber_cpp/library/StepRegistry.cpp
@@ -64,7 +64,7 @@ namespace cucumber_cpp::library
         return list;
     }
 
-    void StepRegistry::Register(const std::string& matcher, engine::StepType stepType, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table))
+    void StepRegistry::Register(const std::string& matcher, engine::StepType stepType, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString))
     {
         if (matcher.starts_with('^') || matcher.ends_with('$'))
             registry.emplace_back(stepType, cucumber_expression::Matcher{ std::in_place_type<cucumber_expression::RegularExpression>, matcher }, factory);

--- a/cucumber_cpp/library/StepRegistry.hpp
+++ b/cucumber_cpp/library/StepRegistry.hpp
@@ -8,7 +8,6 @@
 #include "cucumber_cpp/library/engine/StepType.hpp"
 #include "cucumber_cpp/library/engine/Table.hpp"
 #include <any>
-#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <memory>
@@ -22,20 +21,20 @@
 namespace cucumber_cpp::library
 {
     template<class T>
-    std::unique_ptr<Body> StepBodyFactory(Context& context, const engine::Table& table)
+    std::unique_ptr<Body> StepBodyFactory(Context& context, const engine::Table& table, const std::string& docString)
     {
-        return std::make_unique<T>(context, table);
+        return std::make_unique<T>(context, table, docString);
     }
 
     struct StepMatch
     {
-        StepMatch(std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table), std::variant<std::vector<std::string>, std::vector<std::any>> matches, std::string_view stepRegexStr)
+        StepMatch(std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString), std::variant<std::vector<std::string>, std::vector<std::any>> matches, std::string_view stepRegexStr)
             : factory(factory)
             , matches(std::move(matches))
             , stepRegexStr(stepRegexStr)
         {}
 
-        std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table);
+        std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString);
         std::variant<std::vector<std::string>, std::vector<std::any>> matches{};
         std::string_view stepRegexStr{};
     };
@@ -58,7 +57,7 @@ namespace cucumber_cpp::library
 
         struct Entry
         {
-            Entry(engine::StepType type, cucumber_expression::Matcher regex, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table))
+            Entry(engine::StepType type, cucumber_expression::Matcher regex, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString))
                 : type(type)
                 , regex(std::move(regex))
                 , factory(factory)
@@ -66,7 +65,7 @@ namespace cucumber_cpp::library
 
             engine::StepType type{};
             cucumber_expression::Matcher regex;
-            std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table);
+            std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString);
 
             std::uint32_t used{ 0 };
         };
@@ -91,7 +90,7 @@ namespace cucumber_cpp::library
         [[nodiscard]] std::vector<EntryView> List() const;
 
     private:
-        void Register(const std::string& matcher, engine::StepType stepType, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table));
+        void Register(const std::string& matcher, engine::StepType stepType, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString));
 
         std::vector<Entry> registry;
         cucumber_expression::ParameterRegistry& parameterRegistry;
@@ -107,7 +106,7 @@ namespace cucumber_cpp::library
 
         struct Entry
         {
-            Entry(engine::StepType type, std::string regex, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table))
+            Entry(engine::StepType type, std::string regex, std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString))
                 : type(type)
                 , regex(std::move(regex))
                 , factory(factory)
@@ -115,7 +114,7 @@ namespace cucumber_cpp::library
 
             engine::StepType type{};
             std::string regex;
-            std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table);
+            std::unique_ptr<Body> (&factory)(Context& context, const engine::Table& table, const std::string& docString);
         };
 
         template<class T>

--- a/cucumber_cpp/library/engine/FeatureFactory.cpp
+++ b/cucumber_cpp/library/engine/FeatureFactory.cpp
@@ -166,7 +166,7 @@ namespace cucumber_cpp::library::engine
 
             try
             {
-                scenarioInfo.Children().push_back(featureTreeFactory.CreateStepInfo(stepTypeLut.at(*pickleStep.type), pickleStep.text, scenarioInfo, step.location.line, step.location.column.value_or(0), std::move(table), docString));
+                scenarioInfo.Children().push_back(featureTreeFactory.CreateStepInfo(stepTypeLut.at(*pickleStep.type), pickleStep.text, scenarioInfo, step.location.line, step.location.column.value_or(0), std::move(table), std::move(docString)));
             }
             catch (const std::out_of_range&)
             {

--- a/cucumber_cpp/library/engine/FeatureFactory.hpp
+++ b/cucumber_cpp/library/engine/FeatureFactory.hpp
@@ -20,7 +20,7 @@ namespace cucumber_cpp::library::engine
     {
         explicit FeatureTreeFactory(StepRegistry& stepRegistry);
 
-        [[nodiscard]] std::unique_ptr<StepInfo> CreateStepInfo(StepType stepType, std::string stepText, const ScenarioInfo& scenarioInfo, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table) const;
+        [[nodiscard]] std::unique_ptr<StepInfo> CreateStepInfo(StepType stepType, std::string stepText, const ScenarioInfo& scenarioInfo, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::string docString) const;
 
         [[nodiscard]] std::unique_ptr<FeatureInfo> Create(const std::filesystem::path& path, std::string_view tagExpression) const;
 

--- a/cucumber_cpp/library/engine/Step.cpp
+++ b/cucumber_cpp/library/engine/Step.cpp
@@ -8,9 +8,10 @@
 
 namespace cucumber_cpp::library::engine
 {
-    Step::Step(Context& context, const Table& table)
+    Step::Step(Context& context, const Table& table, const std::string& docString)
         : context{ context }
         , table{ table }
+        , docString{ docString }
     {}
 
     void Step::Given(const std::string& step) const

--- a/cucumber_cpp/library/engine/Step.hpp
+++ b/cucumber_cpp/library/engine/Step.hpp
@@ -24,7 +24,7 @@ namespace cucumber_cpp::library::engine
             std::source_location sourceLocation;
         };
 
-        Step(Context& context, const Table& table);
+        Step(Context& context, const Table& table, const std::string& docString);
         virtual ~Step() = default;
 
         virtual void SetUp()
@@ -46,6 +46,7 @@ namespace cucumber_cpp::library::engine
 
         Context& context;
         const Table& table;
+        const std::string& docString;
     };
 }
 

--- a/cucumber_cpp/library/engine/StepInfo.cpp
+++ b/cucumber_cpp/library/engine/StepInfo.cpp
@@ -10,34 +10,37 @@
 
 namespace cucumber_cpp::library::engine
 {
-    StepInfo::StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table)
+    StepInfo::StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::string docString)
         : scenarioInfo{ scenarioInfo }
         , text{ std::move(text) }
         , type{ type }
         , line{ line }
         , column{ column }
         , table{ std::move(table) }
+        , docString{ std::move(docString) }
     {
     }
 
-    StepInfo::StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, struct StepMatch stepMatch)
+    StepInfo::StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::string docString, struct StepMatch stepMatch)
         : scenarioInfo{ scenarioInfo }
         , text{ std::move(text) }
         , type{ type }
         , line{ line }
         , column{ column }
         , table{ std::move(table) }
+        , docString{ std::move(docString) }
         , stepMatch{ std::move(stepMatch) }
     {
     }
 
-    StepInfo::StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::vector<struct StepMatch> stepMatches)
+    StepInfo::StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::string docString, std::vector<struct StepMatch> stepMatches)
         : scenarioInfo{ scenarioInfo }
         , text{ std::move(text) }
         , type{ type }
         , line{ line }
         , column{ column }
         , table{ std::move(table) }
+        , docString{ std::move(docString) }
         , stepMatch{ std::move(stepMatches) }
     {
     }
@@ -70,6 +73,11 @@ namespace cucumber_cpp::library::engine
     [[nodiscard]] const std::vector<std::vector<TableValue>>& StepInfo::Table() const
     {
         return table;
+    }
+
+    const std::string& StepInfo::DocString() const
+    {
+        return docString;
     }
 
     const std::variant<std::monostate, struct StepMatch, std::vector<struct StepMatch>>& StepInfo::StepMatch() const

--- a/cucumber_cpp/library/engine/StepInfo.hpp
+++ b/cucumber_cpp/library/engine/StepInfo.hpp
@@ -16,9 +16,9 @@ namespace cucumber_cpp::library::engine
 
     struct StepInfo
     {
-        StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table);
-        StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, StepMatch);
-        StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::vector<StepMatch>);
+        StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::string docString);
+        StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::string docString, StepMatch);
+        StepInfo(const struct ScenarioInfo& scenarioInfo, std::string text, StepType type, std::size_t line, std::size_t column, std::vector<std::vector<TableValue>> table, std::string docString, std::vector<StepMatch>);
 
         [[nodiscard]] const struct ScenarioInfo& ScenarioInfo() const;
 
@@ -29,6 +29,7 @@ namespace cucumber_cpp::library::engine
         [[nodiscard]] std::size_t Column() const;
 
         [[nodiscard]] const std::vector<std::vector<TableValue>>& Table() const;
+        [[nodiscard]] const std::string& DocString() const;
         [[nodiscard]] const std::variant<std::monostate, struct StepMatch, std::vector<struct StepMatch>>& StepMatch() const;
 
     private:
@@ -41,6 +42,7 @@ namespace cucumber_cpp::library::engine
         std::size_t column;
 
         std::vector<std::vector<TableValue>> table;
+        std::string docString;
         std::variant<std::monostate, struct StepMatch, std::vector<struct StepMatch>> stepMatch;
     };
 

--- a/cucumber_cpp/library/engine/TestExecution.cpp
+++ b/cucumber_cpp/library/engine/TestExecution.cpp
@@ -63,7 +63,7 @@ namespace cucumber_cpp::library::engine
         const auto& stepContext = contextManager.StepContext();
         auto& scenarioContext = contextManager.ScenarioContext();
 
-        stepMatch.factory(scenarioContext, stepContext.info.Table())->Execute(stepMatch.matches);
+        stepMatch.factory(scenarioContext, stepContext.info.Table(), stepContext.info.DocString())->Execute(stepMatch.matches);
     }
 
     TestExecutionImpl::TestExecutionImpl(cucumber_cpp::library::engine::ContextManager& contextManager, report::ReportForwarder& reportHandler, HookExecutor& hookExecution, const Policy& executionPolicy)

--- a/cucumber_cpp/library/engine/TestRunner.cpp
+++ b/cucumber_cpp/library/engine/TestRunner.cpp
@@ -50,7 +50,7 @@ namespace cucumber_cpp::library::engine
 
     void TestRunnerImpl::NestedStep(StepType type, std::string step)
     {
-        const auto nestedStep = featureTreeFactory.CreateStepInfo(type, std::move(step), *currentScenario, 0, 0, {});
+        const auto nestedStep = featureTreeFactory.CreateStepInfo(type, std::move(step), *currentScenario, 0, 0, {}, "");
         testExecution.RunStep(*nestedStep);
     }
 

--- a/cucumber_cpp/library/engine/test/TestContextManager.cpp
+++ b/cucumber_cpp/library/engine/test/TestContextManager.cpp
@@ -20,7 +20,7 @@ namespace cucumber_cpp::library::engine
         cucumber_cpp::library::engine::FeatureInfo feature{ {}, {}, {}, {}, {}, {} };
         cucumber_cpp::library::engine::RuleInfo rule{ feature, {}, {}, {}, {}, {} };
         cucumber_cpp::library::engine::ScenarioInfo scenario{ rule, {}, {}, {}, {}, {} };
-        cucumber_cpp::library::engine::StepInfo step{ scenario, {}, {}, {}, {}, {} };
+        cucumber_cpp::library::engine::StepInfo step{ scenario, {}, {}, {}, {}, {}, {} };
     };
 
     TEST_F(TestContextManager, Construct)

--- a/cucumber_cpp/library/engine/test/TestStep.cpp
+++ b/cucumber_cpp/library/engine/test/TestStep.cpp
@@ -33,10 +33,12 @@ namespace cucumber_cpp::library::engine
             std::vector{ TableValue{ "value1" }, TableValue{ "value2}" } }
         };
 
+        const std::string docString = "multiline \n string";
+
         library::engine::test_helper::ContextManagerInstance contextManager;
 
         engine::test_helper::TestRunnerMock testRunnerMock;
-        StepMock step{ contextManager.StepContext(), table };
+        StepMock step{ contextManager.StepContext(), table, docString };
     };
 
     TEST_F(TestStep, StepProvidesAccessToSetUpFunction)

--- a/cucumber_cpp/library/engine/test_helper/ContextManagerInstance.hpp
+++ b/cucumber_cpp/library/engine/test_helper/ContextManagerInstance.hpp
@@ -28,7 +28,7 @@ namespace cucumber_cpp::library::engine::test_helper
             , feature{ tags, {}, {}, {}, {}, {} }
             , rule{ feature, {}, {}, {}, {}, {} }
             , scenario{ rule, tags, {}, {}, {}, {} }
-            , step{ scenario, {}, {}, {}, {}, {} }
+            , step{ scenario, {}, {}, {}, {}, {}, {} }
         {
         }
 

--- a/cucumber_cpp/library/test/TestSteps.cpp
+++ b/cucumber_cpp/library/test/TestSteps.cpp
@@ -58,7 +58,7 @@ namespace cucumber_cpp::library
         auto contextStorage{ std::make_shared<ContextStorageFactoryImpl>() };
         Context context{ contextStorage };
 
-        matches.factory(context, {})->Execute(matches.matches);
+        matches.factory(context, {}, "")->Execute(matches.matches);
 
         EXPECT_THAT(context.Contains("float"), testing::IsTrue());
         EXPECT_THAT(context.Contains("std::string"), testing::IsTrue());
@@ -85,7 +85,7 @@ namespace cucumber_cpp::library
         auto contextStorage{ std::make_shared<ContextStorageFactoryImpl>() };
         Context context{ contextStorage };
 
-        matches.factory(context, {})->Execute(matches.matches);
+        matches.factory(context, {}, {})->Execute(matches.matches);
     }
 
     TEST_F(TestSteps, EscapedParenthesis)

--- a/external/cucumber/gherkin/CMakeLists.txt
+++ b/external/cucumber/gherkin/CMakeLists.txt
@@ -1,6 +1,6 @@
 FetchContent_Declare(cucumber_gherkin
     GIT_REPOSITORY https://github.com/cucumber/gherkin.git
-    GIT_TAG "0022bb07791485cda296e1785f4d0de47a04e5c9"
+    GIT_TAG "7cd0304c39a51ac139a22264ebe2a7ce6c68819d"
 )
 
 FetchContent_MakeAvailable(cucumber_gherkin)


### PR DESCRIPTION
Adds support for Gherkin doc string https://cucumber.io/docs/gherkin/reference/#doc-strings

AST from gherkin parser already has the node for it, so just add it to the Step class.