### PR TITLE
fix: float regex on windows

### DIFF
--- a/cucumber_cpp/library/cucumber_expression/ParameterRegistry.cpp
+++ b/cucumber_cpp/library/cucumber_expression/ParameterRegistry.cpp
@@ -80,7 +80,7 @@ namespace cucumber_cpp::library::cucumber_expression
     {
         const static std::string integerNegativeRegex{ R"__(-?\d+)__" };
         const static std::string integerPositiveRegex{ R"__(\d+)__" };
-        const static std::string floatRegex{ R"__((?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][+-]?\d+)?)__" };
+        const static std::string floatRegex{ R"__([-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?)__" };
         const static std::string stringRegex{ R"__("([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)')__" };
         const static std::string wordRegex{ R"__([^\s]+)__" };
         const static std::string anonymousRegex{ R"__(.*)__" };

--- a/cucumber_cpp/library/cucumber_expression/test/TestExpression.cpp
+++ b/cucumber_cpp/library/cucumber_expression/test/TestExpression.cpp
@@ -79,7 +79,6 @@ namespace cucumber_cpp::library::cucumber_expression
                     const auto expression = Expression{ testdata["expression"].as<std::string>(), parameterRegistry };
                     const auto matchOpt = expression.MatchToArguments(testdata["text"].as<std::string>());
 
-                    const auto arguments = expression.MatchToArguments(testdata["text"].as<std::string>());
 
                     ASSERT_THAT(matchOpt, testing::IsTrue()) << FormatTestFailureMessage(file, testdata, expression);
 


### PR DESCRIPTION
Got regression on windows (linux works fine). 

Float regex caused exception _regex_error(error_stack): There was insufficient memory to determine whether the regular expression could match the spec_. Researched alternative regex that seems to have same functionality without excessive look-aheads .
Crash can be observed on existing test case: https://github.com/philips-software/amp-cucumber-cpp-runner/blob/external/alextech/testdata/cucumber-expression/matching/matches-bigdecimal.yaml , so no new tests is being added.

Also, while debugging found unused variable. Cleaned it up one time.

If the branch external/alextech can be rebased or recreated with latest changes I can redirect towards it.

