### PR TITLE
feat: add per-step duration to JUnit XML system-out

### DIFF
--- a/cucumber_cpp/library/formatter/JunitXmlFormatter.cpp
+++ b/cucumber_cpp/library/formatter/JunitXmlFormatter.cpp
@@ -80,7 +80,7 @@ namespace cucumber_cpp::library::formatter
             };
         }
 
-        std::string FormatStep(const cucumber::messages::step& gherkinStep, const cucumber::messages::pickle_step& pickleStep, cucumber::messages::test_step_result_status status)
+        std::string FormatStep(const cucumber::messages::step& gherkinStep, const cucumber::messages::pickle_step& pickleStep, cucumber::messages::test_step_result_status status, std::chrono::milliseconds duration)
         {
             auto statusString = std::string{ cucumber::messages::to_string(status) };
             std::transform(statusString.begin(), statusString.end(), statusString.begin(), [](unsigned char c)
@@ -88,7 +88,7 @@ namespace cucumber_cpp::library::formatter
                     return std::tolower(c);
                 });
 
-            return fmt::format("{:.<76}{}", util::Trim(gherkinStep.keyword) + " " + util::Trim(pickleStep.text), statusString);
+            return fmt::format("{:.<76}{} ({} ms)", util::Trim(gherkinStep.keyword) + " " + util::Trim(pickleStep.text), statusString, duration.count());
         }
 
         std::string MakeOutput(query::Query& query, const cucumber::messages::test_case_started& testCaseStarted)
@@ -105,7 +105,8 @@ namespace cucumber_cpp::library::formatter
                                       const auto [testStepFinished, testStep] = pair;
                                       const auto& pickleStep = *query.FindPickleStepBy(*testStep);
                                       const auto& gherkinStep = query.FindStepBy(pickleStep);
-                                      return FormatStep(gherkinStep, pickleStep, testStepFinished->test_step_result.status);
+                                      const auto durationMs = util::DurationToMilliseconds(query.FindTestStepDurationByTestStepId(testStepFinished->test_step_id));
+                                      return FormatStep(gherkinStep, pickleStep, testStepFinished->test_step_result.status, durationMs);
                                   });
 
             return fmt::format("\n{}\n", fmt::join(outputView, "\n"));


### PR DESCRIPTION
## Summary

Currently the JUnit XML output records timing at the scenario level (<testcase time="...">) but the <system-out> block only shows step name and status, with no indication of how long each step took.

This change adds the wall-clock duration in milliseconds to each step line in <system-out>.

## Before

Then the system starts the application within "3" seconds...................failed

## After

Then the system starts the application within "3" seconds...................failed (3001 ms)

## Details

The duration is recorded independently of pass/fail status — on a failure the value reflects the actual measured time until the step threw (e.g. an RPP timeout), which is the real observed latency. This makes it possible to harvest performance data (e.g. app start time) from the XML artifact in CI without any changes to step implementations.

The timing data is already tracked by Query::FindTestStepDurationByTestStepId — this change simply surfaces it in the formatter output.